### PR TITLE
Improve commands

### DIFF
--- a/src/command_line.py
+++ b/src/command_line.py
@@ -15,7 +15,7 @@ class CL:
         self._width = canvas.get_width()
         self._canvas_height = canvas.get_height()
         self._height = 160
-        self._line_height = 30
+        self._line_height = 25
         self._n_rows_shown = self._get_n_rows_shown(self._height, self._line_height)
         self._n_rows_shown_ref = self._n_rows_shown
         self._height_ref = self._height

--- a/src/commands.py
+++ b/src/commands.py
@@ -119,12 +119,12 @@ class Help(Command):
                     out_string += f"'{name}' or "
                 out_string = out_string[:-4]
                 try:
-                    out_string += " which take values "
+                    out_string += ", which takes values: "
                     for val in arg[1]:
                         out_string += f"'{val}' or "
                     out_string = out_string[:-4]
                 except IndexError:
-                    out_string = out_string[:-19]
+                    out_string = out_string[:-22]
             elif type(arg) == str:
                 out_string += arg
             cmd_line.input.value = out_string

--- a/src/commands.py
+++ b/src/commands.py
@@ -4,8 +4,6 @@ import pygame
 
 from src.events_definition import CMD_FULL_SCREEN, CMD_REGULAR_SIZE
 
-COMMAND_LIST = ["help", "h", "command line", "cl"]
-
 
 class Command:
     """Command class containing all the information for a CL command."""
@@ -66,6 +64,9 @@ class Command:
         return user_args, message
 
 
+HELP_ARGUMENTS = [[("command line", "cl")]]
+
+
 class Help(Command):
     """Help command."""
 
@@ -79,7 +80,7 @@ class Help(Command):
             "extended_description": "During the game, you will learn different commands to "
             "interact with the different elements of the game. Use the help command to check "
             "the use of a particular command.",
-            "arguments": COMMAND_LIST,
+            "arguments": HELP_ARGUMENTS,
             "examples": ["help", "help <command>", "h <command>"],
         }
         super().__init__(**parameters)
@@ -90,22 +91,49 @@ class Help(Command):
             args, message = self.parse_arguments(arguments)
             if message:
                 cmd_line.input.value = message
+                write_command_resonse(cmd_line)
             elif len(args) > 1:
                 cmd_line.input.value = (
                     "When using 'help', only one command can be requested."
                 )
+                write_command_resonse(cmd_line)
             else:
                 cmd = cmd_dict[args[0]]
-                cmd_line.input.value = (
-                    f"{cmd.name}: {cmd.description} {cmd.extended_description}"
-                    f"Available arguments are: {cmd.arguments}. Usage: {cmd.examples}"
-                )
+                self.get_cmd_help_string(cmd_line, cmd)
         else:
-            cmd_line.input.value = (
-                f"{self.description} {self.extended_description}. "
-                f"Usage: {self.examples}"
-            )
+            self.get_cmd_help_string(cmd_line, self)
+
+    def get_cmd_help_string(self, cmd_line, cmd):
+        """Print description of a command with its possible arguments and examples."""
+        cmd_line.input.value = (
+            f"'{cmd.name}' or '{cmd.short_name}': "
+            f"{cmd.description} {cmd.extended_description}"
+        )
         write_command_resonse(cmd_line)
+        cmd_line.input.value = "Available arguments are:"
+        write_command_resonse(cmd_line)
+        for arg in cmd.arguments:
+            out_string = f"  - "
+            if type(arg) == list:
+                for name in arg[0]:
+                    out_string += f"'{name}' or "
+                out_string = out_string[:-4]
+                try:
+                    out_string += " which take values "
+                    for val in arg[1]:
+                        out_string += f"'{val}' or "
+                    out_string = out_string[:-4]
+                except IndexError:
+                    out_string = out_string[:-19]
+            elif type(arg) == str:
+                out_string += arg
+            cmd_line.input.value = out_string
+            write_command_resonse(cmd_line)
+        cmd_line.input.value = "Usage:"
+        write_command_resonse(cmd_line)
+        for example in cmd.examples:
+            cmd_line.input.value = f"  - {example}"
+            write_command_resonse(cmd_line)
 
 
 class Cmd_line(Command):

--- a/src/execute_commands.py
+++ b/src/execute_commands.py
@@ -1,6 +1,6 @@
 """Module in charge of triggering CL commands."""
 
-from src.commands import COMMAND_LIST, cmd_dict, write_command_resonse
+from src.commands import cmd_dict, write_command_resonse
 from src.events_definition import CMD_FULL_SCREEN, CMD_REGULAR_SIZE
 
 
@@ -30,7 +30,7 @@ def trigger_user_commands(cmd_line):
 
 def get_command_from_user_input(user_input):
     """Return main command and the arguments introduced by the user."""
-    for command in COMMAND_LIST:
+    for command in cmd_dict.keys():
         index_ini = user_input.find(command)
         if not index_ini == -1:
             break


### PR DESCRIPTION
Fix #19.

Improve the description of all commands using the ``help`` command. 

Now it is much more readable. Also, ``help`` lists all the available commands.