### PR TITLE
Use enter to enter in CL focus mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,6 +42,7 @@ while run:
             quit()
 
         activate_cl_commands(event, cmd_line)
+        cmd_line.check_focus(event)
 
     # Build layout
     build_canvas(canvas=canvas, screen=screen, cmd_line=cmd_line)

--- a/src/command_line.py
+++ b/src/command_line.py
@@ -22,7 +22,7 @@ class CL:
         self._history = []
         self._surface = self._get_surface(self._width, self._height)
         self._input = self._get_input(self._height)
-        self._input.focus = True
+        self._input.focus = False
         # This allows to always be able to type. This can be changed in the future.
         self._full_screen = False
         self._user_input = ""
@@ -36,7 +36,7 @@ class CL:
             maxlength=80,
             color=WHITE,
             y=(vertical_location - self._line_height),
-            prompt="> ",
+            prompt="",
         )
 
     @staticmethod
@@ -97,6 +97,26 @@ class CL:
         """Return number of shown rows for CL history."""
         return self._n_rows_shown
 
+    def check_prompt(self):
+        """Check the CL prompt."""
+        if self._input.focus:
+            self._input.prompt = "> "
+        else:
+            self._input.prompt = ""
+
+    def check_focus(self, event):
+        """Check whether CL is on focus mode or not."""
+        if event.type == pygame.KEYDOWN:
+            if event.key == pygame.K_RETURN and self._input.focus == False:
+                self._input.focus = True
+            elif (
+                event.key == pygame.K_RETURN
+                and self._input.focus == True
+                and self._input.value == ""
+            ):
+                self._input.focus = False
+        self.check_prompt()
+
     def draw_history(self):
         """Draw command line's history on command line."""
         for i_line in range(self._n_rows_shown):
@@ -121,6 +141,8 @@ class CL:
 
         # Reset input and print
         self._input.value = ""
+        self._input.focus = False
+        self.check_prompt()
         self._input.draw(self._surface)
 
     def maximize(self):
@@ -183,6 +205,7 @@ class CL:
 
 def write_command_response(cmd_line, prompt="  "):
     """Write on CL the content of input.value and store it in CL history."""
+    cmd_line.input.focus = False
     cmd_line.input.prompt = prompt
     cmd_line.reset_after_enter(cmd_line.input.value)
-    cmd_line.input.prompt = "> "
+    # cmd_line.input.prompt = "> "

--- a/src/command_line.py
+++ b/src/command_line.py
@@ -23,7 +23,6 @@ class CL:
         self._surface = self._get_surface(self._width, self._height)
         self._input = self._get_input(self._height)
         self._input.focus = False
-        # This allows to always be able to type. This can be changed in the future.
         self._full_screen = False
         self._user_input = ""
         self._scroll_id = 0
@@ -211,4 +210,3 @@ def write_command_response(cmd_line, prompt="  "):
     cmd_line.input.focus = False
     cmd_line.input.prompt = prompt
     cmd_line.reset_after_enter(cmd_line.input.value)
-    # cmd_line.input.prompt = "> "

--- a/src/command_line.py
+++ b/src/command_line.py
@@ -115,6 +115,9 @@ class CL:
                 and self._input.value == ""
             ):
                 self._input.focus = False
+            if event.key == pygame.K_ESCAPE:
+                self._input.focus = False
+                self._input.value = ""
         self.check_prompt()
 
     def draw_history(self):


### PR DESCRIPTION
1. Use enter to enter CL focus mode
2. Leave focus mode after entering a command (or entering nothing) with the return key.
3. Use escape key to discard the current user input and leave the CL focus mode.